### PR TITLE
Support npm 8, react 17 and react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^4.2.4",


### PR DESCRIPTION
Peer dependencies behaves differently from Npm 8 which caused

    npm install react@17 @piwikpro/react-piwik-pro

To throw an error with Npm 8, but not with Npm 6.

Changing peerDependencies react restriction to allow `^17.0.0` and `^18.0.0`
seems to solve the issue.
```
$ node --version
v16.15.1

$ npm --version
8.11.0

$ npm i react@17 @piwikpro/react-piwik-pro
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"17" from the root project
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.0.0" from @piwikpro/react-piwik-pro@1.0.1
npm ERR! node_modules/@piwikpro/react-piwik-pro
npm ERR!   @piwikpro/react-piwik-pro@"*" from the root project
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```