### PR TITLE
fix: ecommerce customDimensions

### DIFF
--- a/example/src/components/ECommerce/ProductDetailView.tsx
+++ b/example/src/components/ECommerce/ProductDetailView.tsx
@@ -1,4 +1,4 @@
-import { Product } from '../../../../src/interfaces/product.ts'
+import { Product } from '@piwikpro/react-piwik-pro'
 import { FunctionComponent } from 'react'
 import {
   Dialog,

--- a/example/src/pages/ECommercePage.tsx
+++ b/example/src/pages/ECommercePage.tsx
@@ -1,7 +1,5 @@
 import { FunctionComponent, useEffect, useState } from 'react'
-import { Product } from '../../../src/interfaces/product.ts'
-import { PaymentInformation } from '../../../src/interfaces/payment.ts'
-import { eCommerce } from '@piwikpro/react-piwik-pro'
+import { eCommerce, Product, PaymentInformation } from '@piwikpro/react-piwik-pro'
 import { useSnackbar } from 'notistack'
 import {
   Box,
@@ -29,8 +27,8 @@ const products: Product[] = [
     variant: 'Variant 1',
     price: 9.99,
     customDimensions: {
-      dimension1: 'value1',
-      dimension2: 'value2'
+      1: 'value1',
+      2: 'value2'
     }
   },
   {
@@ -41,8 +39,8 @@ const products: Product[] = [
     variant: 'Variant 2',
     price: 19.98,
     customDimensions: {
-      dimension1: 'value1',
-      dimension2: 'value2'
+      1: 'value1',
+      2: 'value2'
     }
   },
   {
@@ -53,8 +51,8 @@ const products: Product[] = [
     variant: 'Variant 3',
     price: 29.97,
     customDimensions: {
-      dimension1: 'value1',
-      dimension2: 'value2'
+      1: 'value1',
+      2: 'value2'
     }
   },
   {
@@ -65,8 +63,8 @@ const products: Product[] = [
     variant: 'Variant 4',
     price: 39.96,
     customDimensions: {
-      dimension1: 'value1',
-      dimension2: 'value2'
+      1: 'value1',
+      2: 'value2'
     }
   },
   {
@@ -77,8 +75,8 @@ const products: Product[] = [
     variant: 'Variant 5',
     price: 49.95,
     customDimensions: {
-      dimension1: 'value1',
-      dimension2: 'value2'
+      1: 'value1',
+      2: 'value2'
     }
   },
   {
@@ -89,8 +87,8 @@ const products: Product[] = [
     variant: 'Variant 6',
     price: 59.94,
     customDimensions: {
-      dimension1: 'value1',
-      dimension2: 'value2'
+      1: 'value1',
+      2: 'value2'
     }
   }
 ]

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,9 @@ export * as SiteSearch from './services/site-search/site-search.service';
 export * as UserManagement from './services/user-management/userManagement.service';
 export * as DataLayer from './services/dataLayer/dataLayer.service';
 
+export * from './interfaces/payment';
+export * from './interfaces/product';
+
 export default {
   initialize: PiwikPro.default.init,
 }

--- a/src/interfaces/product.ts
+++ b/src/interfaces/product.ts
@@ -1,5 +1,7 @@
 import { LimitedArrayFiveStrings } from './utils'
 
+type DimensionId = number;
+
 export type Product = {
   sku: string,
   name?: string,
@@ -8,5 +10,5 @@ export type Product = {
   quantity?: number,
   brand?: string,
   variant?: string,
-  customDimensions?: object,
+  customDimensions?: Record<DimensionId, string>,
 }


### PR DESCRIPTION
We have to send only dimension id ex. `1` instead of full name `dimension1` when supplying ecommerce `customDimensions`. Otherwise we see errors in the debugger
![image](https://github.com/PiwikPRO/react-piwik-pro/assets/49625375/4ad6535c-c3ef-4708-85dd-d24fddc2a2fa)

also export `Product` and `PaymentInformation` types from lib