### PR TITLE
[PPI-1511] add new methods for download classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,9 +1025,12 @@ ___
 ### Table of contents
 
 
+- [addDownloadClasses](#adddownloadclasses)
 - [addDownloadExtensions](#adddownloadextensions)
 - [enableLinkTracking](#enablelinktracking)
+- [getDownloadClasses](#getdownloadclasses)
 - [getLinkTrackingTimer](#getlinktrackingtimer)
+- [removeDownloadClasses](#removedownloadclasses)
 - [removeDownloadExtensions](#removedownloadextensions)
 - [setDownloadClasses](#setdownloadclasses)
 - [setDownloadExtensions](#setdownloadextensions)
@@ -1036,6 +1039,24 @@ ___
 - [setLinkTrackingTimer](#setlinktrackingtimer)
 - [trackLink](#tracklink)
 
+
+#### addDownloadClasses
+
+▸ **addDownloadClasses**(`classes`): `void`
+
+Adds new classes to the download classes list
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `classes` | `string`[] |
+
+##### Returns
+
+`void`
+
+___
 
 #### addDownloadExtensions
 
@@ -1076,6 +1097,18 @@ to a downloadable file creates a download event
 
 ___
 
+#### getDownloadClasses
+
+▸ **getDownloadClasses**(): `Promise`\<`string`[]\>
+
+Returns list of download classes (CSS classes that indicate a link is a download)
+
+##### Returns
+
+`Promise`\<`string`[]\>
+
+___
+
 #### getLinkTrackingTimer
 
 ▸ **getLinkTrackingTimer**(): `Promise`\<`number`\>
@@ -1085,6 +1118,24 @@ Returns lock/wait time after a request set by setLinkTrackingTimer
 ##### Returns
 
 `Promise`\<`number`\>
+
+___
+
+#### removeDownloadClasses
+
+▸ **removeDownloadClasses**(`classes`): `void`
+
+Removes classes from the download classes list
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `classes` | `string`[] |
+
+##### Returns
+
+`void`
 
 ___
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -465,14 +465,14 @@
     fastq "^1.6.0"
 
 "@piwikpro/react-piwik-pro@file:..":
-  version "2.5.0"
+  version "2.6.0"
   dependencies:
-    "@piwikpro/tracking-base-library" "^1.6.0"
+    "@piwikpro/tracking-base-library" "^1.7.0"
 
-"@piwikpro/tracking-base-library@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@piwikpro/tracking-base-library/-/tracking-base-library-1.6.0.tgz#c08ac7331c514e9c2610669720cac9f99bad6a9b"
-  integrity sha512-jd88qqxGAtjSfdDLPuFzrk1hjnIQKCdSFynm3GE/fHB0drPsXZ/o1oXPY9YpAVX2dIkurrycRAzEhtC6KwSlfw==
+"@piwikpro/tracking-base-library@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@piwikpro/tracking-base-library/-/tracking-base-library-1.7.0.tgz#322f1f958ee9bd7a7e637d53c5458ad134ee3fb0"
+  integrity sha512-0u5YTcYO2As9T6ZFuJn0da6VYWz0sVYFFujkwiD8fz0o+Jjvl8r8Fk7rM2/ifLs03bqBOYe8MZRCjDKHWQzaiQ==
 
 "@popperjs/core@^2.11.8":
   version "2.11.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piwikpro/react-piwik-pro",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Piwik PRO tracking library for ReactJS",
   "author": "Piwik Pro Integration Team <integrations@piwik.pro>",
   "license": "MIT",
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-unicode-property-regex": "^7.18.6",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.5.2",
@@ -47,23 +48,22 @@
     "@typescript-eslint/eslint-plugin": "^6.18.0",
     "@typescript-eslint/parser": "^6.18.0",
     "babel-eslint": "^10.1.0",
+    "concat-md": "^0.5.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "gh-pages": "^6.1.1",
     "prettier": "^3.1.1",
     "react": "^18.2.0",
-    "typescript": "^5.2.2",
-    "@rollup/plugin-typescript": "^11.1.6",
-    "concat-md": "^0.5.1",
     "tslib": "^2.6.3",
     "typedoc": "^0.25.13",
     "typedoc-plugin-markdown": "^3.17.1",
+    "typescript": "^5.2.2",
     "vite": "^5.3.1"
   },
   "files": [
     "dist"
   ],
   "dependencies": {
-    "@piwikpro/tracking-base-library": "^1.6.0"
+    "@piwikpro/tracking-base-library": "^1.7.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,10 +355,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@piwikpro/tracking-base-library@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@piwikpro/tracking-base-library/-/tracking-base-library-1.6.0.tgz#c08ac7331c514e9c2610669720cac9f99bad6a9b"
-  integrity sha512-jd88qqxGAtjSfdDLPuFzrk1hjnIQKCdSFynm3GE/fHB0drPsXZ/o1oXPY9YpAVX2dIkurrycRAzEhtC6KwSlfw==
+"@piwikpro/tracking-base-library@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@piwikpro/tracking-base-library/-/tracking-base-library-1.7.0.tgz#322f1f958ee9bd7a7e637d53c5458ad134ee3fb0"
+  integrity sha512-0u5YTcYO2As9T6ZFuJn0da6VYWz0sVYFFujkwiD8fz0o+Jjvl8r8Fk7rM2/ifLs03bqBOYe8MZRCjDKHWQzaiQ==
 
 "@rollup/plugin-typescript@^11.1.6":
   version "11.1.6"


### PR DESCRIPTION
Bumps tracking-base-library and this package's version to prepare for new release

**Note: this PR bumps `react-piwik-pro` to 2.6.0**